### PR TITLE
chore: update lib-gh to 1.0.2

### DIFF
--- a/packages/bot-web-ui/package.json
+++ b/packages/bot-web-ui/package.json
@@ -70,7 +70,7 @@
         "@datadog/browser-logs": "^4.36.0",
         "@deriv/bot-skeleton": "^1.0.0",
         "@deriv/components": "^1.0.0",
-        "@deriv/deriv-charts": "^2.0.5",
+        "@deriv/deriv-charts": "^1.0.0",
         "@deriv/shared": "^1.0.0",
         "@deriv/stores": "^1.0.0",
         "@deriv/translations": "^1.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -105,7 +105,7 @@
         "@deriv/cfd": "^1.0.0",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
-        "@deriv/deriv-charts": "^2.0.5",
+        "@deriv/deriv-charts": "^1.0.0",
         "@deriv/hooks": "^1.0.0",
         "@deriv/library": "^1.0.0",
         "@deriv/p2p": "^0.7.3",

--- a/packages/trader/package.json
+++ b/packages/trader/package.json
@@ -91,7 +91,7 @@
         "@deriv/api-types": "^1.0.118",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
-        "@deriv/deriv-charts": "^2.0.5",
+        "@deriv/deriv-charts": "^1.0.0",
         "@deriv/hooks": "^1.0.0",
         "@deriv/reports": "^1.0.0",
         "@deriv/shared": "^1.0.0",


### PR DESCRIPTION
This PR updates lib-gh to 1.0.2